### PR TITLE
Fix applicationKeyId support, due api changes in b2_list_buckets

### DIFF
--- a/src/s3ql/backends/backblaze.py
+++ b/src/s3ql/backends/backblaze.py
@@ -64,7 +64,7 @@ class Backend(AbstractBackend, metaclass=ABCDocstMeta):
 
         self._login()
 
-        self._connect_bucket(self.bucket_name)
+        self._connect_bucket(self.bucket_name, self.bucket_id)
 
     def _do_request(self, method, path, conn, headers=None, body=None, auth_token=None, download_body=True,
                     body_size=None):
@@ -180,28 +180,30 @@ class Backend(AbstractBackend, metaclass=ABCDocstMeta):
             self.auth_token = j['authorizationToken']
             self.download_host = download_url.hostname
 
+            """ Define restricted bucketId (in case ApplicationKey used instead AccountId) """
+            self.bucket_id = j['allowed']['bucketId']
+
             self.conn_api = HTTPConnection(self.api_host, 443, ssl_context=self.ssl_context)
             self.conn_download = HTTPConnection(self.download_host, 443, ssl_context=self.ssl_context)
 
-    def _connect_bucket(self, bucket_name):
-        """
-        Get id of bucket_name
-        """
-
+    def _connect_bucket(self, bucket_name, bucket_id):
         log.debug('started with %s' % (bucket_name))
-
-        resp, body = self._do_request('GET', '/b2api/v1/b2_list_buckets?accountId=%s' % self.account_id, self.conn_api)
-        bucket_id = None
-        j = json.loads(str(body, encoding='UTF-8'))
-
-        for b in j['buckets']:
-            if b['bucketName'] == bucket_name:
-                bucket_id = b['bucketId']
-
         if bucket_id is None:
-            raise DanglingStorageURLError(bucket_name)
-        self.bucket_id = bucket_id
-        self.bucket_name = bucket_name
+            """ Get id of bucket_name """
+            resp, body = self._do_request('GET', '/b2api/v1/b2_list_buckets?accountId=%s' % self.account_id, self.conn_api)
+            bucket_id = None
+            j = json.loads(str(body, encoding='UTF-8'))
+
+            for b in j['buckets']:
+                if b['bucketName'] == bucket_name:
+                    bucket_id = b['bucketId']
+
+            if bucket_id is None:
+                raise DanglingStorageURLError(bucket_name)
+            self.bucket_id = bucket_id
+            self.bucket_name = bucket_name
+        else:
+            pass
 
     def _add_meta_headers(self, headers, metadata):
         self._add_meta_headers_s3(headers, metadata,


### PR DESCRIPTION
On Sept 13, 2018 BackBlaze changed api call b2_list_buckets, if you use applicationKeyId (instead master key) restricted to one bucket - api always return "unauthorized"
I made changes to code, which check
1. If user use applicationKeyId restricted to one bucket - skip the b2_list_buckets call and use buckedId which was get on auth.
2. If user use AccountID/Master key - determining buckedId as before, by b2_list_buckets call.